### PR TITLE
Include systemd documentation for run on boot

### DIFF
--- a/configuration/running-on-boot.md
+++ b/configuration/running-on-boot.md
@@ -5,19 +5,19 @@ systemd is the default init system for most modern distros.
 
 You need to create a service file in `/etc/systemd/system/`
 
-Example `ts3.service`
+Example `ts3server.service`
 ```
 [Unit]
-Description=Teamspeak3 Server utilizing Linux Game Server Manager
+Description=LinuxGSM Teamspeak3 Server
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-User=lgsm
-WorkingDirectory=/home/lgsm/ts3
-ExecStart=/home/lgsm/ts3/ts3server start
-ExecStop=/home/lgsm/ts3/ts3server stop
+User=ts3server
+WorkingDirectory=/home/ts3server
+ExecStart=/home/ts3server/ts3server start
+ExecStop=/home/ts3server/ts3server stop
 Restart=no
 RemainAfterExit=yes   #Assume that the service is running after main process exits with code 0
 
@@ -31,10 +31,10 @@ You need to reload the systemd-daemon once to make it aware of the new service f
 
 Now you can do
 ```bash
-systemctl start ts3 # Start the server
-systemctl stop ts3  # Stop the server
-systemctl enable ts3 # Enable start on boot
-systemctl disable ts3 # Disable start on boot
+systemctl start ts3server # Start the server
+systemctl stop ts3server  # Stop the server
+systemctl enable ts3server # Enable start on boot
+systemctl disable ts3server # Disable start on boot
 ```
 
 ## Crontab
@@ -77,4 +77,3 @@ rc.local is another method to run scripts on boot. Any commands added to the rc.
 nano /etc/rc.local
 su - username -c '/home/username/gameserver start'
 ```
-

--- a/configuration/running-on-boot.md
+++ b/configuration/running-on-boot.md
@@ -13,11 +13,13 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 User=lgsm
 WorkingDirectory=/home/lgsm/ts3
 ExecStart=/home/lgsm/ts3/ts3server start
 ExecStop=/home/lgsm/ts3/ts3server stop
+Restart=no
+RemainAfterExit=yes   #Assume that the service is running after main process exits with code 0
 
 [Install]
 WantedBy=multi-user.target

--- a/configuration/running-on-boot.md
+++ b/configuration/running-on-boot.md
@@ -1,5 +1,40 @@
 # Running on Boot
 
+## Using systemd
+systemd is the default init system for most modern distros.
+
+You need to create a service file in `/etc/systemd/system/`
+
+Example `ts3.service`
+```
+[Unit]
+Description=Teamspeak3 Server utilizing Linux Game Server Manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=lgsm
+WorkingDirectory=/home/lgsm/ts3
+ExecStart=/home/lgsm/ts3/ts3server start
+ExecStop=/home/lgsm/ts3/ts3server stop
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Replace the user and paths to fit your setup.
+
+You need to reload the systemd-daemon once to make it aware of the new service file by `systemctl daemon-reload`
+
+Now you can do
+```bash
+systemctl start ts3 # Start the server
+systemctl stop ts3  # Stop the server
+systemctl enable ts3 # Enable start on boot
+systemctl disable ts3 # Disable start on boot
+```
+
 ## Crontab
 
 The crontab will allow you to create \[\[cronjobs\]\] that allow you to run a command on a set time or on boot. The below examples uses `@reboot` that will run a command on boot.
@@ -10,7 +45,7 @@ The crontab will allow you to create \[\[cronjobs\]\] that allow you to run a co
 
 > note: Most admins will also have a timed monitor cronjob configured. If you do not want to have extra cronjobs the timed monitor will also start a server but with a timed delay.
 
-### Using `monitor` command \(recommended\)
+### Using `monitor` command
 
 After a reboot, any game server that has a "started" status will be started on boot. Servers that were manually stopped will remain stopped.
 


### PR DESCRIPTION
systemd is the default init system for most modern distros and should be preferred over crontabs and SysVinit

I included a simple service file for a teamspeak 3 server that can be easily adopted to other servers as well