### PR TITLE
FastDL SVG support

### DIFF
--- a/commands/fastdl.md
+++ b/commands/fastdl.md
@@ -21,7 +21,7 @@ Short: `./gameserver fd`
 ## Supported file formats
 
 * Maps \(.bsp\)
-* Materials \(.vtf, .vmt\)
+* Materials \(.vtf, .vmt, .png, .svg\)
 * Models \(.vtx, .vvd, .mdl, .phy\)
 * Particles \(.pcf\)
 * Sounds \(.wav, .mp3, .ogg\)

--- a/commands/fastdl.md
+++ b/commands/fastdl.md
@@ -26,7 +26,7 @@ Short: `./gameserver fd`
 * Particles \(.pcf\)
 * Sounds \(.wav, .mp3, .ogg\)
 * Fonts \(.otf, .ttf\)
-* Images \(.png\)
+* Images \(.png, .svg\)
 
 ## Requirements
 


### PR DESCRIPTION
CS:GO with Panorama now supports SVG custom logos, which are displayed in more places than a PNG logo.