### PR TITLE
Added quotes to fix boot errors

### DIFF
--- a/game-servers/ark-survival-evolved.md
+++ b/game-servers/ark-survival-evolved.md
@@ -60,7 +60,7 @@ To change command-line parameters for your server edit your '_/lgsm/config-lgsm/
 
 ```text
 fn_parms(){
-  parms="\"TheIsland?SessionName=MyServerName1?AltSaveDirectoryName=Save1?Port=7777?QueryPort=27015" -NoTransferFromFiltering -clusterid=cluster1"
+  parms="\"TheIsland?SessionName=MyServerName1?AltSaveDirectoryName=Save1?Port=7777?QueryPort=27015" -NoTransferFromFiltering -clusterid=cluster1\""
 }
 ```
 


### PR DESCRIPTION
If copypasted like most will do, they will get a `cant find pane arkserver` error on boot, this fixes that