### PR TITLE
type=forking, not: type=simple

### DIFF
--- a/configuration/running-on-boot.md
+++ b/configuration/running-on-boot.md
@@ -15,7 +15,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=forking
 User=ts3server
 WorkingDirectory=/home/ts3server
 ExecStart=/home/ts3server/ts3server start


### PR DESCRIPTION
see top-answer of https://unix.stackexchange.com/questions/137028/why-is-my-systemd-unit-loaded-but-inactive-dead
systemclt shall watch the child-process of "ts3server start", not "ts3server" itself.