### PR TITLE
fix: jq update centos 7

### DIFF
--- a/requirements/jq.md
+++ b/requirements/jq.md
@@ -9,6 +9,6 @@
 | Debian 8 | 1.4 |
 | Debian 9 | 1.5 |
 | Debian 10 | 1.5 |
-| CentOS 7 | 1.5 |
+| CentOS 7 | 1.6 |
 | CentOS 8 | 1.5 |
 


### PR DESCRIPTION
CentOS 7 got a update for jq recently (epel repo)
Update link form fedora system: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2020-ec6f2e57cb