### PR TITLE
Removed postdays and posttarget

### DIFF
--- a/alerts/README.md
+++ b/alerts/README.md
@@ -13,8 +13,6 @@ More info allows you to get further info about an alert using hastebin.com. Many
 ```text
 # More info | https://docs.linuxgsm.com/alerts#more-info
 postalert="off"
-postdays="7"
-posttarget="https://hastebin.com"
 ```
 
 ### Display IP


### PR DESCRIPTION
Removed postdays and posttarget from the more info example as these options are no longer valid due to the postdetails command being hardcoded to use termbin