### PR TITLE
docs: added arma3 troubleshooting section with "BattlEye initialization failed" solution

### DIFF
--- a/game-servers/arma-3.md
+++ b/game-servers/arma-3.md
@@ -122,3 +122,7 @@ You should see something similar to the following in your `console` [log](../fea
  1:21:05 ==========================================================================================================================================================================================================
 ```
 
+## Troubleshooting
+
+### "BattlEye initialization failed"
+If you see this message while connecting to your server, try to open the port 2306 (UDP) in your firewall.


### PR DESCRIPTION
This fixed for me the issue, see: 
https://community.bistudio.com/wiki/Arma_3:_Dedicated_Server#Port_Forwarding
"2306 (BattlEye traffic, +4)"

Maybe its also nice to add it to `./arma3server details` ports section?