### PR TITLE
Update documentation to use NodeJS 16.x

### DIFF
--- a/requirements/gamedig.md
+++ b/requirements/gamedig.md
@@ -35,14 +35,14 @@ Installing nodejs can be problematic, however, using the below should work well.
 #### Ubuntu/Debian
 
 ```text
-curl -fsSL https://deb.nodesource.com/setup_15.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt update && sudo apt install -y nodejs
 ```
 
 #### CentOS
 
 ```text
-curl -fsSL https://rpm.nodesource.com/setup_15.x | bash -
+curl -fsSL https://rpm.nodesource.com/setup_16.x | bash -
 yum install nodejs npm
 ```
 


### PR DESCRIPTION
Update documentation to use NodeJS 16.x due to end of life for 15.x:

```
Node.js 15.x is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"
   * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
   * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"


  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions
```

Tested and working on NodeJS 16.