### PR TITLE
docs: add LostIsland official map name

### DIFF
--- a/game-servers/ark-survival-evolved.md
+++ b/game-servers/ark-survival-evolved.md
@@ -37,6 +37,7 @@ The default save directory is the default map name. However with the `altsavedir
 * Valguero\_P
 * Genesis
 * CrystalIsles
+* LostIsland
 
 ## Mod Support
 


### PR DESCRIPTION
Adding LostIsland to the official ARK map names