### PR TITLE
Fixed same-line commenting

### DIFF
--- a/configuration/running-on-boot.md
+++ b/configuration/running-on-boot.md
@@ -18,7 +18,8 @@ Wants=network-online.target
 Type=forking
 User=ts3server
 WorkingDirectory=/home/ts3server
-RemainAfterExit=yes   #Assume that the service is running after main process exits with code 0
+#Assume that the service is running after main process exits with code 0
+RemainAfterExit=yes
 ExecStart=/home/ts3server/ts3server start
 ExecStop=/home/ts3server/ts3server stop
 Restart=no


### PR DESCRIPTION
Having this comment on the same line as the setting causes this service to fail on most systemctl distros. I moved it to its own line.