### PR TITLE
Update lan-discovery.md: disable virtual network

### DIFF
--- a/steamcmd/lan-discovery.md
+++ b/steamcmd/lan-discovery.md
@@ -36,3 +36,4 @@ As [this github issue](https://github.com/GameServerManagers/LinuxGSM/issues/177
 2. Change `ip="0.0.0.0"` to an actual interface IP, for example `ip="192.168.1.10"` ; this will allow LinuxGSM to [monitor](../commands/monitor.md) and query your server properly.
 3. In the `fn_parms` section, add `+sv_lan 1` and make sure you replace `-ip ${ip}` with `-ip 0.0.0.0`
 4. Make sure your server main port listens to one of these IP or IP ranges: 4242 ; 26900-26905 ; 27015-27020 ; 27215
+5. Disable any virtual network adapter on the client (e.g. when using VirtualBox)


### PR DESCRIPTION
I was looking for fixes, but no one mentioned this. So I'am adding it to the docs. Originally I found it here: https://github.com/GameServerManagers/LinuxGSM-Docker/issues/4