### PR TITLE
docs: replace old node-gamedig link reference to actual repo

### DIFF
--- a/requirements/gamedig.md
+++ b/requirements/gamedig.md
@@ -1,6 +1,6 @@
 # gamedig
 
-[GameDig](https://github.com/sonicsnes/node-gamedig) is a tool that queries game servers and returns outputs data from a query into json format. It can not only check if the game server is online but also return various data such as current maps and players. This allows `./gameserver details` to display live information.
+[GameDig](https://github.com/gamedig/node-gamedig) is a tool that queries game servers and returns outputs data from a query into json format. It can not only check if the game server is online but also return various data such as current maps and players. This allows `./gameserver details` to display live information.
 
 GameDig super-seeds gsquery as the tool to monitor game servers. GameDig is currently optional but recommended and gsquery is kept to ensure compatibility as gamedig requires Node.js to be installed.
 


### PR DESCRIPTION
### Description
Replaces the link reference to the node-GameDig repository to the actual one.

### Why?
The link redirects to the actual repository, but this is just a tidy small change to be up to date with it :)

### Other references
Have made the same replacement in [LinuxGSM#4338](https://github.com/GameServerManagers/LinuxGSM/pull/4338), also mentioned that the same link occurs once here.