### PR TITLE
docs(alerts): document nullmailer as Postfix alternative for email alerts

### DIFF
--- a/alerts/email.md
+++ b/alerts/email.md
@@ -8,6 +8,8 @@ LinuxGSM will send an email using the `mail` command.
 
 Postfix or equivalent must be setup and correctly configured before sending emails. Failure to correctly configure Postfix and a domain for your server will mean the email alert may be flagged as spam or not arrive at all. Configuring postfix is not covered here, but there are many tutorials online to help.
 
+If you only need to relay outbound alert emails through an external SMTP provider rather than run a full mail server, [nullmailer](https://www.nongnu.org/nullmailer/) is a lightweight alternative to Postfix. On Debian/Ubuntu, LinuxGSM will detect an existing nullmailer setup (`/etc/nullmailer`) and install `mailutils` alongside it instead of `postfix`, so an existing nullmailer relay won't be overwritten by LinuxGSM's dependency check.
+
 {% hint style="success" %}
 [Mailgun](broken-reference) is a paid service with 3 month free trial that can be used as an email relay to reduce the chances of email alerts being blocked as spam.
 {% endhint %}
@@ -17,7 +19,7 @@ Postfix or equivalent must be setup and correctly configured before sending emai
 To enable email alerts you will need to add an email address to the [LinuxGSM config](../configuration/linuxgsm-config.md).
 
 ```bash
-# Email Alerts | https://github.com/GameServerManagers/LinuxGSM/wiki/Email
+# Email Alerts | https://docs.linuxgsm.com/alerts/email
 emailalert="off"
 email="email@example.com"
 emailfrom=""


### PR DESCRIPTION
## Summary
- Documents nullmailer as a lightweight relay-only alternative to Postfix for email alerts, matching the behavior added in GameServerManagers/LinuxGSM#4871 (check_deps.sh now detects an existing nullmailer setup and installs mailutils instead of postfix alongside it).
- Fixes a stale link in the config example (old GitHub wiki URL -> current docs.linuxgsm.com page), matching what the actual _default.cfg files reference.

## Related
- GameServerManagers/LinuxGSM#4871