### PR TITLE
docs(stop): expand stoponlyifnoplayers + add stoponlyifnoplayersallcommands

### DIFF
--- a/commands/start-stop-restart.md
+++ b/commands/start-stop-restart.md
@@ -18,10 +18,21 @@ Stop will attempt a [graceful shutdown](../features/stop-mode.md) of a game serv
 
 #### Stop only if empty (optional)
 
-If `stoponlyifnoplayers` setting is enabled LinuxGSM will only stop the server if it is empty and prevent it from stopping otherwise. This feature only works with game servers that can use gamedig.
+If the `stoponlyifnoplayers` setting is enabled, LinuxGSM will only stop the server when it is empty and prevent it from stopping otherwise. This feature requires [gamedig](../requirements/gamedig.md) and a working query (`querymode` 2 or 3).
 
 ```properties
 stoponlyifnoplayers="off"
+```
+
+When a `restart` is requested while players are online, the restart is **postponed** rather than cancelled: LinuxGSM records a restart request and the [monitor](monitor.md) command will retry the restart automatically once the server is empty. Enable a monitor cronjob for postponed restarts to be carried out.
+
+By default this protection applies to **all** commands that stop the server, including `update`. To limit it to only the explicit `stop` and `restart` commands (so an `update` can still stop the server even while players are online), set `stoponlyifnoplayersallcommands` to `off`.
+
+```properties
+# Apply "stop only if empty" to every command that stops the server (default).
+stoponlyifnoplayersallcommands="on"
+# Or limit it to explicit stop/restart only:
+# stoponlyifnoplayersallcommands="off"
 ```
 
 ### Restarting a server


### PR DESCRIPTION
Documents the stop-only-if-empty behaviour for GameServerManagers/LinuxGSM#4595:
- Clarifies that a restart with players online is postponed (not cancelled) and retried by monitor once empty.
- Documents the new `stoponlyifnoplayersallcommands` setting (default on = applies to all stop-causing commands incl. update; off = only explicit stop/restart).

## Related
- GameServerManagers/LinuxGSM#4595