### PR TITLE
docs: document DST caves/mods setup and add locale FAQ entry

### DIFF
--- a/game-servers/dont-starve-together.md
+++ b/game-servers/dont-starve-together.md
@@ -113,6 +113,64 @@ For clarity it is recommended recommend naming the master shard _**Master**_.
 
 Lastly you have to start both servers. The order does not matter because the slave server will auto-retry connecting to the master server which is listening.
 
+### Caves
+
+Setting `cave="true"` on a shard is all that is required to turn it into an actual cave, LinuxGSM handles the rest automatically during install.
+
+{% hint style="info" %}
+`cave` only affects world generation. It has no effect unless `sharding="true"` and `shard` is set to a unique name for that instance, as shown in the `dstserver-2` example above.
+{% endhint %}
+
+When a server is installed with `cave="true"`, LinuxGSM writes the following file for you:
+
+~/.klei/DoNotStarveTogether/Cluster\_1/Caves/worldgenoverride.lua
+
+```lua
+return { override_enabled = true, preset = "DST_CAVE", }
+```
+
+This is what tells the game to generate an underground cave map for that shard instead of a normal overworld. Without it, a "Caves" shard would just generate a second overworld map. Since this file is only written on install, changing `cave` on an already-installed shard requires a fresh install (or a reinstall) of that instance to regenerate the world with the new preset.
+
+## Installing Mods
+
+LinuxGSM does not install or manage Don't Starve Together mods automatically, this has to be done manually in three steps.
+
+### 1. Enable mods for download
+
+Add each mod's Steam Workshop ID to `dedicated_server_mods_setup.lua` so the dedicated server downloads it from the Workshop.
+
+~/serverfiles/mods/dedicated_server_mods_setup.lua
+
+```lua
+ServerModSetup("378160973")
+ServerModSetup("some-other-workshop-id")
+```
+
+Run `./dstserver update` (or `install`) afterwards so the mods get downloaded.
+
+### 2. Enable mods per shard
+
+Each shard (Master and Caves) needs its own `modoverrides.lua` listing which mods are enabled for that shard.
+
+~/.klei/DoNotStarveTogether/Cluster\_1/Master/modoverrides.lua
+
+```lua
+return {
+  ["workshop-378160973"] = { enabled = true },
+  ["workshop-some-other-workshop-id"] = { enabled = true },
+}
+```
+
+{% hint style="warning" %}
+Note the `workshop-` prefix before the ID in `modoverrides.lua`. This is different from `dedicated_server_mods_setup.lua`, which uses the bare ID.
+{% endhint %}
+
+Copy the same file into the `Caves` shard directory if you want the mod active there too, most world/gameplay mods need to be enabled on both shards to behave consistently.
+
+### 3. Configure mod settings (optional)
+
+Some mods expose extra configuration options (difficulty, spawn rates, etc). The easiest way to generate a correctly formatted `modoverrides.lua` with these settings is to temporarily host a non-dedicated client server with the same mods enabled, configure the mods through the in-game mod options UI, generate the world once, then copy the resulting `modoverrides.lua` from that client's save folder over to both the Master and Caves shard directories on the dedicated server.
+
 ## Guides / Documentations:
 
 * [Quick Setup](http://forums.kleientertainment.com/topic/64441-dedicated-server-quick-setup-guide-linux/)

--- a/support/faq.md
+++ b/support/faq.md
@@ -141,6 +141,26 @@ Find and edit the following line and change it to the IP address you want to use
 ip="0.0.0.0"
 ```
 
+## WARNING: setlocale('en\_US.UTF-8') failed, using locale: 'C'
+
+```
+WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
+```
+
+SteamCMD expects the `en_US.UTF-8` locale to be installed and generated on your system. If it isn't, SteamCMD falls back to the `C` locale and warns about it on every run. This is a system locale issue, not a LinuxGSM bug, but the fix is quick.
+
+On Debian/Ubuntu, generate the locale with:
+
+```
+dpkg-reconfigure locales
+```
+
+Select (or enable) `en_US.UTF-8 UTF-8` from the list, then let it regenerate.
+
+On other distros, use the equivalent locale tool, for example `locale-gen en_US.UTF-8` followed by `update-locale`.
+
+If you are already using a different UTF-8 locale (for example `hu_HU.UTF-8`), the warning still appears because SteamCMD specifically looks for `en_US.UTF-8`. You need to have it installed alongside your preferred locale.
+
 ## version \`GLIBC\_2.15′ not found
 
 ```


### PR DESCRIPTION
Adds the missing content requested in #86 and #82.

## Dont Starve Together (#86)
- Explains that setting cave="true" on a shard is all that is needed, and that LinuxGSM automatically writes worldgenoverride.lua with the DST_CAVE preset on install (verified against install_config.sh)
- Notes this only regenerates on a fresh install/reinstall of that shard
- Adds a full Installing Mods section: dedicated_server_mods_setup.lua for download, per-shard modoverrides.lua for enabling, and the client-hosted-server trick for generating mod option configs, based on the guide linked in #86

## FAQ (#82)
- Adds the setlocale(en_US.UTF-8) failed warning, migrated from the old GitHub wiki FAQ (see linked LinuxGSM issue #2038) which never made it into the new docs

Closes #86
Closes #82